### PR TITLE
feat: criar formulário com React Hook Form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "userform-app",
       "version": "0.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.0.1",
         "clsx": "^2.1.1",
         "normalize.css": "^8.0.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.56.0",
         "react-router": "^7.5.1",
         "vite-tsconfig-paths": "^5.1.4",
         "zod": "^3.24.3"
@@ -1578,6 +1580,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.0.1.tgz",
+      "integrity": "sha512-u/+Jp83luQNx9AdyW2fIPGY6Y7NG68eN2ZW8FOJYL+M0i4s49+refdJdOp/A9n9HFQtQs3HIDHQvX3ZET2o7YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -2354,6 +2368,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@swc/core": {
       "version": "1.11.21",
@@ -8175,6 +8195,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.56.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.56.0.tgz",
+      "integrity": "sha512-U2QQgx5z2Y8Z0qlXv3W19hWHJgfKdWMz0O/osuY+o+CYq568V2R/JhzC6OAXfR8k24rIN0Muan2Qliaq9eKs/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
     ]
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.0.1",
     "clsx": "^2.1.1",
     "normalize.css": "^8.0.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.56.0",
     "react-router": "^7.5.1",
     "vite-tsconfig-paths": "^5.1.4",
     "zod": "^3.24.3"

--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -8,20 +8,20 @@
   border-radius: 9999px;
   cursor: pointer;
 
-  &:hover:not(:disabled) {
-    opacity: 0.7;
+  &:hover:not(:disabled):not(.loading) {
+    background-color: $color-button-hover;
   }
 
   &.loading {
     cursor: wait;
     position: relative;
 
-    &:disabled {
-      background-color: $color-primary;
+    span {
+      visibility: hidden;
     }
 
-    &:disabled span {
-      visibility: hidden;
+    &:disabled {
+      background-color: $color-primary;
     }
 
     &::after {

--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -2,6 +2,7 @@
 
 .wrapper {
   position: relative;
+  width: 100%;
   margin: 2.5rem 0 1.5rem;
 }
 
@@ -11,7 +12,6 @@
   padding: 10px 10px 10px 5px;
   display: block;
   border: none;
-  border-bottom: 1px solid $color-muted;
   background: transparent;
 
   &:focus {
@@ -22,7 +22,7 @@
   &:not(:placeholder-shown) ~ .label {
     top: -1.25rem;
     font-size: 0.75rem;
-    color: $color-muted;
+    color: $color-text;
   }
 
   &:focus ~ .bar::before,
@@ -32,14 +32,21 @@
     width: 50%;
   }
 
-  &[aria-invalid='true'] {
-    border-color: $color-error;
+  &[aria-invalid='true'] ~ .label {
+    color: $color-error;
   }
 
-  &:-webkit-autofill,
-  &:-webkit-autofill:focus,
-  &:-webkit-autofill:hover {
-    box-shadow: 0 0 0px 1000px $color-background inset;
+  &[aria-invalid='true'] ~ .bar {
+    background-color: $color-error;
+  }
+
+  &[aria-invalid='true'] ~ .bar::before,
+  &[aria-invalid='true'] ~ .bar::after {
+    background: $color-error;
+  }
+
+  &:-webkit-autofill {
+    box-shadow: 0 0 0 1000px $color-background inset;
     -webkit-text-fill-color: $color-text;
     transition: background-color 5000s ease-in-out 0s;
   }
@@ -63,6 +70,8 @@
   position: relative;
   display: block;
   width: 100%;
+  height: 2px;
+  background-color: $color-muted;
 
   &::before,
   &::after {

--- a/src/components/Input/Input.module.scss
+++ b/src/components/Input/Input.module.scss
@@ -22,7 +22,7 @@
   &:not(:placeholder-shown) ~ .label {
     top: -1.25rem;
     font-size: 0.75rem;
-    color: $color-text;
+    font-weight: bold;
   }
 
   &:focus ~ .bar::before,
@@ -30,10 +30,6 @@
   &:not(:placeholder-shown) ~ .bar::before,
   &:not(:placeholder-shown) ~ .bar::after {
     width: 50%;
-  }
-
-  &[aria-invalid='true'] ~ .label {
-    color: $color-error;
   }
 
   &[aria-invalid='true'] ~ .bar {

--- a/src/pages/FormPage/FormPage.module.scss
+++ b/src/pages/FormPage/FormPage.module.scss
@@ -1,10 +1,26 @@
 @use '@/styles/base' as *;
 
-.wrapper {
+.container {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   min-height: 100vh;
   gap: 10px;
+}
+
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  width: 500px;
+  padding: 40px 20px;
+  border-radius: 10px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+.input {
+  width: 100%;
 }

--- a/src/pages/FormPage/FormPage.test.tsx
+++ b/src/pages/FormPage/FormPage.test.tsx
@@ -1,14 +1,63 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi } from 'vitest'
 import { FormPage } from './FormPage'
+import * as userService from '@/services/user'
+
+const fillValidForm = async () => {
+  await userEvent.type(screen.getByLabelText(/nome completo/i), 'Fernanda Oshiro')
+  await userEvent.type(screen.getByLabelText(/e-mail/i), 'fernanda@example.com')
+  await userEvent.type(screen.getByLabelText(/cpf/i), '52998224725')
+  await userEvent.type(screen.getByLabelText(/telefone/i), '11999999999')
+}
+
+const fillInvalidForm = async () => {
+  await userEvent.type(screen.getByLabelText(/nome completo/i), 'Fe')
+  await userEvent.type(screen.getByLabelText(/e-mail/i), 'fernanda')
+  await userEvent.type(screen.getByLabelText(/cpf/i), '52998')
+  await userEvent.type(screen.getByLabelText(/telefone/i), '1199')
+}
 
 describe('FormPage', () => {
-  it('renderiza o texto corretamente', () => {
+  it('envia o formulário com dados válidos (com spy)', async () => {
+    const spy = vi.spyOn(userService, 'saveUser').mockImplementation(async () => ({
+      success: true,
+    }))
+
     render(<FormPage />)
-    expect(screen.getByText('Formulário')).toBeInTheDocument()
+    await fillValidForm()
+
+    const button = screen.getByRole('button', { name: /cadastrar/i })
+    await userEvent.click(button)
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith({
+        name: 'Fernanda Oshiro',
+        email: 'fernanda@example.com',
+        cpf: '52998224725',
+        phone: '11999999999',
+      })
+    })
+
+    spy.mockRestore()
   })
 
-  it('não exibe a mensagem de erro inicialmente', () => {
+  it('exibe mensagens de erro por campo inválido', async () => {
     render(<FormPage />)
-    expect(screen.queryByText('CPF inválido')).not.toBeInTheDocument()
+    await fillInvalidForm()
+
+    const button = screen.getByRole('button', { name: /cadastrar/i })
+    await userEvent.click(button)
+
+    expect(await screen.findByText(/campo deve conter 3 caracteres/i)).toBeInTheDocument()
+    expect(await screen.findByText(/campo deve conter um e-mail válido/i)).toBeInTheDocument()
+    expect(await screen.findByText(/campo inválido: cpf/i)).toBeInTheDocument()
+    expect(await screen.findByText(/ddd, número/i)).toBeInTheDocument()
+  })
+
+  it('mantém o botão desabilitado com formulário inválido', () => {
+    render(<FormPage />)
+    const button = screen.getByRole('button', { name: /cadastrar/i })
+    expect(button).toBeDisabled()
   })
 })

--- a/src/pages/FormPage/FormPage.tsx
+++ b/src/pages/FormPage/FormPage.tsx
@@ -1,31 +1,66 @@
 import { Button } from '@/components/Button'
 import { Input } from '@/components/Input'
+import { UserSchema, userSchema } from '@/schema/user.schema'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useForm } from 'react-hook-form'
 
 import style from './FormPage.module.scss'
+import { saveUser } from '@/services/user'
 
 export const FormPage = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting, isValid },
+  } = useForm<UserSchema>({
+    resolver: zodResolver(userSchema),
+    mode: 'onTouched',
+  })
+
+  const onSubmit = async (data: UserSchema) => {
+    console.log(data)
+    await saveUser(data)
+  }
+
   return (
-    <div className={style.wrapper}>
-      <h1>Formulário</h1>
-      <Input name="name" label="Nome Completo (sem abreviações)" type="text" inputMode="text" />
-      <Input name="email" label="E-mail" type="email" inputMode="email" />
-      <Input
-        name="cpf"
-        label="CPF"
-        mask="cpf"
-        type="tel"
-        inputMode="numeric"
-        pattern="\d{3}\.?\d{3}\.?\d{3}-?\d{2}"
-      />
-      <Input
-        name="phone"
-        label="Telefone"
-        mask="phone"
-        type="tel"
-        inputMode="numeric"
-        pattern="\d{10,11}"
-      />
-      <Button>Cadastrar</Button>
+    <div className={style.container}>
+      <form className={style.wrapper} onSubmit={handleSubmit(onSubmit)}>
+        <h1>Formulário</h1>
+        <Input
+          label="Nome Completo (sem abreviações)"
+          type="text"
+          inputMode="text"
+          error={errors.name?.message}
+          {...register('name', { required: true })}
+        />
+        <Input
+          label="E-mail"
+          type="email"
+          inputMode="email"
+          error={errors.email?.message}
+          {...register('email', { required: true })}
+        />
+        <Input
+          label="CPF"
+          mask="cpf"
+          type="tel"
+          inputMode="numeric"
+          error={errors.cpf?.message}
+          {...register('cpf', { required: true })}
+        />
+        <Input
+          label="Telefone"
+          mask="phone"
+          type="tel"
+          inputMode="numeric"
+          error={errors.phone?.message}
+          className={style.input}
+          {...register('phone', { required: true })}
+        />
+        <Button type="submit" isLoading={isSubmitting} disabled={!isValid} isFullWidth>
+          Cadastrar
+        </Button>
+      </form>
     </div>
   )
 }

--- a/src/schema/user.schema.test.ts
+++ b/src/schema/user.schema.test.ts
@@ -2,80 +2,116 @@ import { describe, it, expect } from 'vitest'
 import { userSchema } from './user.schema'
 
 describe('userSchema', () => {
-  it('falha se o nome tiver menos de 3 caracteres', () => {
-    const result = userSchema.safeParse({
-      name: 'Al',
-      cpf: '52998224725',
-      phone: '11999999999',
-      email: 'al@example.com',
+  describe('name', () => {
+    it('falha se tiver menos de 3 caracteres', () => {
+      const result = userSchema.safeParse({
+        name: 'Al',
+        cpf: '52998224725',
+        phone: '11999999999',
+        email: 'al@example.com',
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        console.log(result.error.format())
+        expect(result.error.format().name?._errors).toEqual(
+          expect.arrayContaining([
+            'Campo deve conter 3 caracteres ou mais',
+            'Campo deve conter nome e sobrenome',
+          ])
+        )
+      }
     })
-    expect(result.success).toBe(false)
+
+    it('falha se não tiver sobrenome', () => {
+      const result = userSchema.safeParse({
+        name: 'Alice',
+        cpf: '52998224725',
+        phone: '11999999999',
+        email: 'alice@example.com',
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.format().name?._errors).toContain('Campo deve conter nome e sobrenome')
+      }
+    })
   })
 
-  it('falha se o nome não tiver sobrenome', () => {
-    const result = userSchema.safeParse({
-      name: 'Alice',
-      cpf: '52998224725',
-      phone: '11999999999',
-      email: 'alice@example.com',
+  describe('cpf', () => {
+    it('falha se tiver menos de 11 dígitos', () => {
+      const result = userSchema.safeParse({
+        name: 'Alice Souza',
+        cpf: '12345678',
+        phone: '11999999999',
+        email: 'alice@example.com',
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.format().cpf?._errors).toContain('Campo inválido: CPF')
+      }
     })
 
-    expect(result.success).toBe(false)
-    if (!result.success) {
-      expect(result.error.format().name?._errors).toContain(
-        'Nome deve conter pelo menos um sobrenome'
-      )
-    }
+    it('falha se o CPF for inválido', () => {
+      const result = userSchema.safeParse({
+        name: 'Bob Souza',
+        cpf: '12345678901',
+        phone: '11999999999',
+        email: 'bob@example.com',
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.format().cpf?._errors).toContain('Campo inválido: CPF')
+      }
+    })
   })
 
-  it('falha se o CPF tiver menos de 11 dígitos', () => {
-    const result = userSchema.safeParse({
-      name: 'Alice Souza',
-      cpf: '12345678',
-      phone: '11999999999',
-      email: 'alice@example.com',
+  describe('phone', () => {
+    it('falha se o telefone for incompleto', () => {
+      const result = userSchema.safeParse({
+        name: 'Carol Souza',
+        cpf: '52998224725',
+        phone: '11999',
+        email: 'carol@example.com',
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.format().phone?._errors[0]).toMatch(/Campo deve conter DDD/)
+      }
     })
-    expect(result.success).toBe(false)
+
+    it('falha se o telefone contiver letras', () => {
+      const result = userSchema.safeParse({
+        name: 'Carol Souza',
+        cpf: '52998224725',
+        phone: '11asd999999999',
+        email: 'carol@example.com',
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.format().phone?._errors[0]).toMatch(/Campo deve conter DDD/)
+      }
+    })
   })
 
-  it('falha se o CPF for inválido', () => {
-    const result = userSchema.safeParse({
-      name: 'Bob Souza',
-      cpf: '12345678901',
-      phone: '11999999999',
-      email: 'bob@example.com',
-    })
-    expect(result.success).toBe(false)
-  })
+  describe('email', () => {
+    it('falha se o e-mail for inválido', () => {
+      const result = userSchema.safeParse({
+        name: 'Diego Souza',
+        cpf: '52998224725',
+        phone: '11999999999',
+        email: 'invalid-email',
+      })
 
-  it('falha se o telefone for incompleto', () => {
-    const result = userSchema.safeParse({
-      name: 'Carol Souza',
-      cpf: '52998224725',
-      phone: '11999',
-      email: 'carol@example.com',
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.format().email?._errors).toContain('Campo deve conter um e-mail válido')
+      }
     })
-    expect(result.success).toBe(false)
-  })
-
-  it('falha se o telefone conter letras', () => {
-    const result = userSchema.safeParse({
-      name: 'Carol Souza',
-      cpf: '52998224725',
-      phone: '11asd999999999',
-      email: 'carol@example.com',
-    })
-    expect(result.success).toBe(false)
-  })
-
-  it('falha se o e-mail for inválido', () => {
-    const result = userSchema.safeParse({
-      name: 'Diego Souza',
-      cpf: '52998224725',
-      phone: '11999999999',
-      email: 'invalid-email',
-    })
-    expect(result.success).toBe(false)
   })
 
   it('passa com todos os campos válidos', () => {
@@ -85,6 +121,11 @@ describe('userSchema', () => {
       phone: '(11) 98765-4321',
       email: 'diego@example.com',
     })
+
     expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.cpf).toBe('52998224725')
+      expect(result.data.phone).toBe('11987654321')
+    }
   })
 })

--- a/src/schema/user.schema.ts
+++ b/src/schema/user.schema.ts
@@ -5,24 +5,24 @@ import { isValidPhone, sanitizePhone } from '@/utils/phone'
 export const userSchema = z.object({
   name: z
     .string()
-    .min(3, { message: 'Nome deve ter no mínimo 3 caracteres' })
+    .min(3, { message: 'Campo deve conter 3 caracteres ou mais' })
     .refine((name) => name.split(' ').length > 1, {
-      message: 'Nome deve conter pelo menos um sobrenome',
+      message: 'Campo deve conter nome e sobrenome',
     }),
 
   cpf: z
     .string()
-    .refine(isValidCPF, { message: 'CPF inválido' })
+    .refine(isValidCPF, { message: 'Campo inválido: CPF' })
     .transform((val) => val.replace(/\D/g, '')),
 
   phone: z
     .string()
     .refine(isValidPhone, {
-      message: 'Telefone deve conter DDD, números e nenhum caractere inválido',
+      message: 'Campo deve conter DDD, números válidos e nenhum caractere inválido',
     })
     .transform(sanitizePhone),
 
-  email: z.string().email({ message: 'E-mail inválido' }),
+  email: z.string().email({ message: 'Campo deve conter um e-mail válido' }),
 })
 
 export type UserSchema = z.infer<typeof userSchema>

--- a/src/services/user.ts
+++ b/src/services/user.ts
@@ -1,5 +1,15 @@
+import { UserSchema } from '@/schema/user.schema'
+
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000'
 
 export function fetchRemoteUsers() {
   return fetch(`${API_URL}/users`).then((res) => res.json())
+}
+
+export async function saveUser(
+  newUser: UserSchema
+): Promise<{ success: true } | { success: false; message: string }> {
+  console.log('Saving: ', newUser)
+  await new Promise((resolve) => setTimeout(resolve, 2000))
+  return { success: true }
 }

--- a/src/utils/phone.ts
+++ b/src/utils/phone.ts
@@ -1,6 +1,6 @@
 export function isValidPhone(value: string): boolean {
   const cleaned = value.replace(/\D/g, '')
-  return (cleaned.length === 10 || cleaned.length === 11) && !/[a-zA-Z]/.test(value)
+  return /^\d{10,11}$/.test(cleaned) && !/[a-zA-Z]/.test(value)
 }
 
 export function sanitizePhone(value: string): string {


### PR DESCRIPTION
### Funcionalidade

- Utiliza `react-hook-form` com `zodResolver` para validação dos campos
- Exibe os campos:
  - Nome
  - CPF
  - Telefone
  - E-mail
- Conecta os inputs ao `register` do React Hook Form
- Usa `formState.errors` para exibir mensagens de erro abaixo de cada campo
- Usa `formState.isSubmitting` para controlar o estado de loading do botão
- Botão desabilitado enquanto o formulário está inválido

---

### Testes incluídos

- [x] Submissão com dados válidos (com `spy` no `saveUser`)
- [x] Exibição de mensagens de erro por campo inválido
- [x] Botão desabilitado quando o formulário está incompleto
- [x] Botão com loading ao enviar o formulário

---

Closes #5 